### PR TITLE
relax sorting rules 

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "request": "launch",
+            "type": "node",
+			"name": "Run mocha",
+			"program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+			// Automatically stop program after launch.
+			"stopOnEntry": false,
+			// Command line arguments passed to the program.
+			"args": ["test"]
+		}
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A small library that parses mssql connection string and returns database configu
 
 
 ## Tests
-
+  `npm install`
   `npm test`
 
 ## Contributing

--- a/index.js
+++ b/index.js
@@ -11,14 +11,14 @@ module.exports = function (connectionString) {
     connectionString.split(';').forEach((x) => {
         const arr = x.split('=');
         if (arr[1]) {
-            result[arr[0]] = arr[1];
+            result[arr[0].toLowerCase()] = arr[1];
         }
     });
 
     // extract host and port from 'Data Source'
     let host;
     let port;
-    const dataSource = result['Data Source'];
+    const dataSource = result['data source'];
     if (dataSource) {
         const regex = /.*:(.*),([0-9]+)/;
         const match = regex.exec(dataSource);
@@ -30,12 +30,14 @@ module.exports = function (connectionString) {
 
     // extract user from 'User Id'
     let user;
-    const userId = result['User Id'];
+    const userId = result['user id'];
     if (userId) {
         const regex = /(.*)@.*/;
         const match = regex.exec(userId);
         if (match) {
             user = match[1];
+        } else {
+            user = userId;
         }
     }
 
@@ -46,22 +48,22 @@ module.exports = function (connectionString) {
     if (!user) {
         throw new Error('User not found');
     }
-    if (!result['Initial Catalog']) {
+    if (!result['initial catalog']) {
         throw new Error('Database not found');
     }
-    if (!result['Password']) {
+    if (!result['password']) {
         throw new Error('Password not found');
     }
 
     return {
         host,
         options: {
-            database: result['Initial Catalog'],
+            database: result['initial catalog'],
             encrypt: true,
             port: port,
         },
         /* tslint:disable */
-        password: result['Password'],
+        password: result['password'],
         /* tslint:enable */
         user,
     };

--- a/test/knexSetup.test.js
+++ b/test/knexSetup.test.js
@@ -18,4 +18,38 @@ describe('#knexSetup', () => {
         const result = parser(connectionString);
         expect(result).to.deep.equal(expectedSetup);
     });
+
+    it('should be case agnostic to the keys in the connection string', () => {
+        const connectionString = 'Data souRCE=tcp:database.com,1433;Initial CataloG=numbers;User ID=service@database.com;PasswoRD=fjsflregewbfldsfhsew3;';
+        const expectedSetup = {
+            'host': 'database.com',
+            'options': {
+                'database': 'numbers',
+                'encrypt': true,
+                'port': '1433',
+            },
+            'password': 'fjsflregewbfldsfhsew3',
+            'user': 'service',
+        };
+
+        const result = parser(connectionString);
+        expect(result).to.deep.equal(expectedSetup);
+    });
+
+    it('should return user that has no @', () => {
+        const connectionString = 'Data souRCE=tcp:database.com,1433;Initial CataloG=numbers;User ID=service;PasswoRD=fjsflregewbfldsfhsew3;';
+        const expectedSetup = {
+            'host': 'database.com',
+            'options': {
+                'database': 'numbers',
+                'encrypt': true,
+                'port': '1433',
+            },
+            'password': 'fjsflregewbfldsfhsew3',
+            'user': 'service',
+        };
+
+        const result = parser(connectionString);
+        expect(result).to.deep.equal(expectedSetup);
+    });
 });

--- a/test/malformedConnectionString.test.js
+++ b/test/malformedConnectionString.test.js
@@ -34,14 +34,6 @@ describe('#malformedConnectionString', () => {
         }).to.throw(Error);
     });
 
-    it('should find missing user', () => {
-        const connectionString = 'Data Source=tcp:database.com,1433;Initial Catalog=numbers;User Id=database.com;Password=fjsflregewbfldsfhsew3;';
-
-        expect(() => {
-            parser(connectionString);
-        }).to.throw(Error);
-    });
-
     it('should find missing "Initial Catalog"', () => {
         const connectionString = 'Data Source=tcp:database.com,1433;Initial=numbers;User Id=service@database.com;Password=fjsflregewbfldsfhsew3;';
 


### PR DESCRIPTION
This PR is not a 100% match for this repository, since I am not using it as an input for knex but just as a parser for mssql connection strings, but I think it will be nice to make it more generic. 

changes: 
- be case agnostic for connection string keys (Both `User ID` and `User Id` should work).
In Azure App Service for example, The connection string that is generated by Azure contains `User ID` with capital D. 
   <img width="566" alt="screen shot 2017-11-13 at 11 51 27 pm" src="https://user-images.githubusercontent.com/8294298/32768763-13adc42c-c8ce-11e7-8a24-98f2ee7961a2.png">
- `@` in the user id  is not required, if it doesn't exist return the entire user instead of throwing.
- update the readme instructions to call `npm install` first before calling `npm test`
- Add vscode configuration, for easy unit tests debugging.