### PR TITLE
Allow missing protocol and port

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,6 @@ module.exports = function (connectionString) {
     if (dataSource) {
         const regexFull = /.*:(.*)/;
         const regexHostPort = /(.*),([0-9]+)/;
-        
         const matchFull = regexFull.exec(dataSource);
         
         if (matchFull) {
@@ -38,12 +37,12 @@ module.exports = function (connectionString) {
         }
         else{
             const matchHostPort2 = regexHostPort.exec(dataSource);
-            if (matchHostPort2) {
+            if (matchHostPort2) {    
                 host = matchHostPort2[1];
                 port = matchHostPort2[2];
             }
             else if (isNaN(dataSource)) {
-                host = datasource;
+                host = dataSource;
             }
         }
     }

--- a/index.js
+++ b/index.js
@@ -74,16 +74,21 @@ module.exports = function (connectionString) {
         throw new Error('Password not found');
     }
 
-    return {
+    var config = {
         host,
         options: {
             database: result['initial catalog'],
-            encrypt: true,
-            port: port,
+            encrypt: true
         },
         /* tslint:disable */
         password: result['password'],
         /* tslint:enable */
         user,
     };
+
+    if (port){
+        config.options.port = port;
+    }
+
+    return config;
 };

--- a/index.js
+++ b/index.js
@@ -20,11 +20,31 @@ module.exports = function (connectionString) {
     let port;
     const dataSource = result['data source'];
     if (dataSource) {
-        const regex = /.*:(.*),([0-9]+)/;
-        const match = regex.exec(dataSource);
-        if (match) {
-            host = match[1];
-            port = match[2];
+        const regexFull = /.*:(.*)/;
+        const regexHostPort = /(.*),([0-9]+)/;
+        
+        const matchFull = regexFull.exec(dataSource);
+        
+        if (matchFull) {
+            const matchHostPort1 = regexHostPort.exec(matchFull[1]);
+            if (matchHostPort1) {
+                host = matchHostPort1[1];
+                port = matchHostPort1[2];
+            }
+            else if (isNaN(matchFull[1])) {
+                
+                host = matchFull[1];
+            }
+        }
+        else{
+            const matchHostPort2 = regexHostPort.exec(dataSource);
+            if (matchHostPort2) {
+                host = matchHostPort2[1];
+                port = matchHostPort2[2];
+            }
+            else if (isNaN(dataSource)) {
+                host = datasource;
+            }
         }
     }
 
@@ -42,8 +62,8 @@ module.exports = function (connectionString) {
     }
 
     // check if all data was found
-    if (!port || !host) {
-        throw new Error('Port or host not found');
+    if (!host) {
+        throw new Error('Host not found');
     }
     if (!user) {
         throw new Error('User not found');

--- a/test/knexSetup.test.js
+++ b/test/knexSetup.test.js
@@ -77,7 +77,6 @@ describe('#knexSetup', () => {
             'options': {
                 'database': 'numbers',
                 'encrypt': true,
-                'port': undefined,
             },
             'password': 'fjsflregewbfldsfhsew3',
             'user': 'service',
@@ -94,7 +93,6 @@ describe('#knexSetup', () => {
             'options': {
                 'database': 'numbers',
                 'encrypt': true,
-                'port': undefined,
             },
             'password': 'fjsflregewbfldsfhsew3',
             'user': 'service',

--- a/test/knexSetup.test.js
+++ b/test/knexSetup.test.js
@@ -52,4 +52,56 @@ describe('#knexSetup', () => {
         const result = parser(connectionString);
         expect(result).to.deep.equal(expectedSetup);
     });
+
+    it('should return proper config when protocol is missing', () => {
+        const connectionString = 'Data Source=database.com,1433;Initial Catalog=numbers;User Id=service@database.com;Password=fjsflregewbfldsfhsew3;';
+        const expectedSetup = {
+            'host': 'database.com',
+            'options': {
+                'database': 'numbers',
+                'encrypt': true,
+                'port': '1433',
+            },
+            'password': 'fjsflregewbfldsfhsew3',
+            'user': 'service',
+        };
+
+        const result = parser(connectionString);
+        expect(result).to.deep.equal(expectedSetup);
+    });
+
+    it('should return proper config when port is missing', () => {
+        const connectionString = 'Data Source=tcp:database.com;Initial Catalog=numbers;User Id=service@database.com;Password=fjsflregewbfldsfhsew3;';
+        const expectedSetup = {
+            'host': 'database.com',
+            'options': {
+                'database': 'numbers',
+                'encrypt': true,
+                'port': undefined,
+            },
+            'password': 'fjsflregewbfldsfhsew3',
+            'user': 'service',
+        };
+
+        const result = parser(connectionString);
+        expect(result).to.deep.equal(expectedSetup);
+    });
+
+    it('should return proper config when protocol and port are missing', () => {
+        const connectionString = 'Data Source=database.com;Initial Catalog=numbers;User Id=service@database.com;Password=fjsflregewbfldsfhsew3;';
+        const expectedSetup = {
+            'host': 'database.com',
+            'options': {
+                'database': 'numbers',
+                'encrypt': true,
+                'port': undefined,
+            },
+            'password': 'fjsflregewbfldsfhsew3',
+            'user': 'service',
+        };
+
+        const result = parser(connectionString);
+        expect(result).to.deep.equal(expectedSetup);
+    });
+
 });

--- a/test/malformedConnectionString.test.js
+++ b/test/malformedConnectionString.test.js
@@ -2,12 +2,12 @@ const expect = require('chai').expect;
 const parser = require('../index');
 
 describe('#malformedConnectionString', () => {
-    it('should find missing port', () => {
+    it('should allow missing port', () => {
         const connectionString = 'Data Source=tcp:database.com;Initial Catalog=numbers;User Id=service@database.com;Password=fjsflregewbfldsfhsew3;';
 
         expect(() => {
             parser(connectionString);
-        }).to.throw(Error);
+        }).to.not.throw(Error);
     });
 
     it('should find missing host', () => {

--- a/test/malformedConnectionString.test.js
+++ b/test/malformedConnectionString.test.js
@@ -9,7 +9,20 @@ describe('#malformedConnectionString', () => {
             parser(connectionString);
         }).to.not.throw(Error);
     });
+    it('should allow missing protocol', () => {
+        const connectionString = 'Data Source=database.com,1433;Initial Catalog=numbers;User Id=service@database.com;Password=fjsflregewbfldsfhsew3;';
 
+        expect(() => {
+            parser(connectionString);
+        }).to.not.throw(Error);
+    });
+    it('should allow missing port and protocol', () => {
+        const connectionString = 'Data Source=database.com;Initial Catalog=numbers;User Id=service@database.com;Password=fjsflregewbfldsfhsew3;';
+
+        expect(() => {
+            parser(connectionString);
+        }).to.not.throw(Error);
+    });
     it('should find missing host', () => {
         const connectionString = 'Data Source=tcp:1433;Initial Catalog=numbers;User Id=service@database.com;Password=fjsflregewbfldsfhsew3;';
 
@@ -17,7 +30,6 @@ describe('#malformedConnectionString', () => {
             parser(connectionString);
         }).to.throw(Error);
     });
-
     it('should find missing "Data Source"', () => {
         const connectionString = 'Data=tcp:database.com,1433;Initial Catalog=numbers;User Id=service@database.com;Password=fjsflregewbfldsfhsew3;';
 
@@ -25,7 +37,6 @@ describe('#malformedConnectionString', () => {
             parser(connectionString);
         }).to.throw(Error);
     });
-
     it('should find missing "User Id"', () => {
         const connectionString = 'Data Source=tcp:database.com,1433;Initial Catalog=numbers;User=service@database.com;Password=fjsflregewbfldsfhsew3;';
 


### PR DESCRIPTION
Hi, I needed to allow for missing protocol and port numbers in my connectionstring, so I refined the parsing of the `data source` result a bit. It only adds the `port` to the result config object if it is found. Also added some tests to illustrate the changes. 